### PR TITLE
Fix usernames appearing in all lowercase 

### DIFF
--- a/Auth_phpbb.php
+++ b/Auth_phpbb.php
@@ -213,6 +213,18 @@ class Auth_phpBB extends AuthPlugin implements iAuthPlugin
     private $_WikiGroupName;
 
     /**
+     * Whether to set usernames from the
+     * username_clean (false) colum or username
+     * (true) column in the phpbb users tables.
+     * Should be true in most cases, is added for
+     * legacy support due to previous versions
+     * setting usernames to lowercase.
+     *
+     * @var bool
+     */
+    private $_UseCanonicalCase;
+
+    /**
      * Constructor
      *
      * @param array $aConfig
@@ -233,6 +245,13 @@ class Auth_phpBB extends AuthPlugin implements iAuthPlugin
         $this->_UseWikiGroup    = $aConfig['UseWikiGroup'];
         $this->_WikiGroupName   = $aConfig['WikiGroupName'];
         $this->_LoginMessage    = $aConfig['LoginMessage'];
+
+        // If undefined (i.e. user is using an old config) set to false
+        if (isset($aConfig['UseCanonicalCase'])) {
+            $this->_UseCanonicalCase = $aConfig['UseCanonicalCase'];
+        } else {
+            $this->_UseCanonicalCase = false;
+        }
 
         // Only assign the database values if a external database is used.
         if ($this->_UseExtDatabase == true)
@@ -477,10 +496,10 @@ class Auth_phpBB extends AuthPlugin implements iAuthPlugin
         $username = $fresMySQLConnection->escape_string($username);
 
         // Check Database for username. We will return the correct casing of the name.
-        $fstrMySQLQuery = sprintf("SELECT `username_clean`
+        $fstrMySQLQuery = sprintf("SELECT `%s`
                 FROM `%s`
                 WHERE `username_clean` = ?
-                LIMIT 1", $this->_UserTB);
+                LIMIT 1", ($this->_UseCanonicalCase ? "username" : "username_clean"), $this->_UserTB);
 
         // Query Database.
         $fresStatement = $fresMySQLConnection->prepare($fstrMySQLQuery);

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ Open LocalSettings.php. Put this at the bottom of the file. Edit as needed.
         require_once './extensions/Auth_phpbb.php';
         
         $wgAuth_Config = array(); // Clean.
+
+        $wgAuth_Config['UseCanonicalCase'] = true;      // Setting this to true causes the mediawiki usernames
+                                                        // to match the casing of the phpbb ones (except with
+                                                        // the first letter set uppercase.)
+                                                        // Setting this to false causes usernames to be all
+                                                        // lowercase except for the first character.
+                                                        // Before June 2016 this setting was always false,
+                                                        // changing it to true on an install where it previously
+                                                        // was false will cause users with uppercase characters
+                                                        // to appear as separate users from their previous
+                                                        // all-lowercase account.
         
         $wgAuth_Config['WikiGroupName'] = 'Wiki';       // Name of your PHPBB group
                                                         // users need to be a member


### PR DESCRIPTION
For some reason it was getting the usernames from the username_clean
column instead of the username column, this means usernames were
appearing in all lowercase (except for the first character.) This fixes
it so that usernames appear in the correct case.

This is however a problem in already installed installations, because it
means that if this is changed then old usernames that were previously made
lowercase will not match up with new ones. So this sets the default to
make all usernames lowercase so as not to break existing installations.