### PR TITLE
Fix 'Auto-creation failed': Add permission for autocreateaccount

### DIFF
--- a/Auth_phpbb.php
+++ b/Auth_phpbb.php
@@ -249,6 +249,7 @@ class Auth_phpBB extends AuthPlugin implements iAuthPlugin
 
         // Specify who may create new accounts:
         $GLOBALS['wgGroupPermissions']['*']['createaccount'] = false;
+        $GLOBALS['wgGroupPermissions']['*']['autocreateaccount'] = true;
 
         // Load Hooks
         $GLOBALS['wgHooks']['UserLoginForm'][]      = array($this, 'onUserLoginForm', false);


### PR DESCRIPTION
The permission autocreateaccount is needed in mediawiki 1.27+ for new
users to log in for the first time, if it's not set then they will
instead get the 'Auto-creation of a local account failed: Automatic
account creation is not allowed.' error.

Fixes bug report #12 