### PR TITLE
Implement username translation from phpBB to Mediawiki using phpBB Cu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,72 +55,72 @@ which are also valid MediaWiki usernames do not need this field set.
 
 Open LocalSettings.php. Put this at the bottom of the file. Edit as needed.
 
-/*-----------------[ Everything below this line. ]-----------------*/
+    /*-----------------[ Everything below this line. ]-----------------*/
+    
+    // phpBB User Database Plugin. (Requires MySQL Database)
+    require_once "$IP/extensions/Auth_phpBB/Auth_phpbb.php";
+    
+    $wgAuth_Config = array(); // Clean.
+    
+    $wgAuth_Config['UseCanonicalCase'] = true;      // Setting this to true causes the MediaWiki usernames
+                                                    // to match the casing of the phpBB ones (except with
+                                                    // the first letter set uppercase.)
+                                                    // Setting this to false causes usernames to be all
+                                                    // lowercase except for the first character.
+                                                    // Before June 2016 this setting was always false,
+                                                    // changing it to true on an install where it previously
+                                                    // was false will cause users with uppercase characters
+                                                    // to appear as separate users from their previous
+                                                    // all-lowercase account.
         
-// phpBB User Database Plugin. (Requires MySQL Database)
-require_once '$IP/extensions/Auth_phpBB/Auth_phpbb.php';
-        
-$wgAuth_Config = array(); // Clean.
+    $wgAuth_Config['WikiGroupName'] = 'Wiki';       // Name of your phpBB group
+                                                    // users need to be a member
+                                                    // of to use the wiki. (i.e. wiki)
+                                                    // This can also be set to an array 
+                                                    // of group names to use more then 
+                                                    // one. (ie. 
+                                                    // $wgAuth_Config['WikiGroupName'][] = 'Wiki';
+                                                    // $wgAuth_Config['WikiGroupName'][] = 'Wiki2';
+                                                    // or
+                                                    // $wgAuth_Config['WikiGroupName'] = array('Wiki', 'Wiki2');
+                                                    // )
+    
+    
+    $wgAuth_Config['UseWikiGroup'] = true;          // This tells the Plugin to require
+                                                    // a user to be a member of the above
+                                                    // phpBB group. (ie. wiki) Setting
+                                                    // this to false will let any phpBB
+                                                    // user edit the wiki.
+    
+    $wgAuth_Config['UseExtDatabase'] = false;       // This tells the plugin that the phpBB tables
+                                                    // are in a different database then the wiki.
+                                                    // The default settings is false.
+    
+    //$wgAuth_Config['MySQL_Host']        = 'localhost';      // phpBB MySQL Host Name.
+    //$wgAuth_Config['MySQL_Port']        = '';               // phpBB MySQL Port number.
+    //$wgAuth_Config['MySQL_Username']    = 'username';       // phpBB MySQL Username.
+    //$wgAuth_Config['MySQL_Password']    = 'password';       // phpBB MySQL Password.
+    //$wgAuth_Config['MySQL_Database']    = 'database';       // phpBB MySQL Database Name.
+    
+    $wgAuth_Config['UserTB']         = 'phpbb3_users';       // Name of your phpBB user table. (i.e. phpbb_users)
+    $wgAuth_Config['GroupsTB']       = 'phpbb3_groups';      // Name of your phpBB groups table. (i.e. phpbb_groups)
+    $wgAuth_Config['User_GroupTB']   = 'phpbb3_user_group';  // Name of your phpBB user_group table. (i.e. phpbb_user_group)
+    $wgAuth_Config['PathToPHPBB']    = '../phpbb3/';         // Path from this file to your phpBB install.
+    $wgAuth_Config['URLToPHPBB']     = 'http://www.domain.com/phpbb3/'; // URL of your phpBB install.
+    
+    $wgAuth_Config['UseWikiProfile']   = false;   // Whether the extension checks for a custom username profile
+                                                  // field in phpBB when the phpBB username is incompatible with
+                                                  // MediaWiki username restrictions.
 
-$wgAuth_Config['UseCanonicalCase'] = true;      // Setting this to true causes the MediaWiki usernames
-                                                // to match the casing of the phpBB ones (except with
-                                                // the first letter set uppercase.)
-                                                // Setting this to false causes usernames to be all
-                                                // lowercase except for the first character.
-                                                // Before June 2016 this setting was always false,
-                                                // changing it to true on an install where it previously
-                                                // was false will cause users with uppercase characters
-                                                // to appear as separate users from their previous
-                                                // all-lowercase account.
-        
-$wgAuth_Config['WikiGroupName'] = 'Wiki';       // Name of your phpBB group
-                                                // users need to be a member
-                                                // of to use the wiki. (i.e. wiki)
-                                                // This can also be set to an array 
-                                                // of group names to use more then 
-                                                // one. (ie. 
-                                                // $wgAuth_Config['WikiGroupName'][] = 'Wiki';
-                                                // $wgAuth_Config['WikiGroupName'][] = 'Wiki2';
-                                                // or
-                                                // $wgAuth_Config['WikiGroupName'] = array('Wiki', 'Wiki2');
-                                                // )
-        
-        
-$wgAuth_Config['UseWikiGroup'] = true;          // This tells the Plugin to require
-                                                // a user to be a member of the above
-                                                // phpBB group. (ie. wiki) Setting
-                                                // this to false will let any phpBB
-                                                // user edit the wiki.
-        
-$wgAuth_Config['UseExtDatabase'] = false;       // This tells the plugin that the phpBB tables
-                                                // are in a different database then the wiki.
-                                                // The default settings is false.
-        
-//$wgAuth_Config['MySQL_Host']        = 'localhost';      // phpBB MySQL Host Name.
-//$wgAuth_Config['MySQL_Port']        = '';               // phpBB MySQL Port number.
-//$wgAuth_Config['MySQL_Username']    = 'username';       // phpBB MySQL Username.
-//$wgAuth_Config['MySQL_Password']    = 'password';       // phpBB MySQL Password.
-//$wgAuth_Config['MySQL_Database']    = 'database';       // phpBB MySQL Database Name.
-        
-$wgAuth_Config['UserTB']         = 'phpbb3_users';       // Name of your phpBB user table. (i.e. phpbb_users)
-$wgAuth_Config['GroupsTB']       = 'phpbb3_groups';      // Name of your phpBB groups table. (i.e. phpbb_groups)
-$wgAuth_Config['User_GroupTB']   = 'phpbb3_user_group';  // Name of your phpBB user_group table. (i.e. phpbb_user_group)
-$wgAuth_Config['PathToPHPBB']    = '../phpbb3/';         // Path from this file to your phpBB install.
-$wgAuth_Config['URLToPHPBB']     = 'http://www.domain.com/phpbb3/'; // URL of your phpBB install.
-
-$wgAuth_Config['UseWikiProfile']   = false;   // Whether the extension checks for a custom username profile
-                                              // field in phpBB when the phpBB username is incompatible with
-                                              // MediaWiki username restrictions.
-
-$wgAuth_Config['ProfileDataTB']    = 'phpbb3_profile_fields_data';  // Name of your phpBB profile data table. (e.g. phpbb_profile_fields_data)
-
-$wgAuth_Config['ProfileFieldName'] = 'pf_wikiusername';             // Name of your phpBB custom profile field
-                                                                    // The 'pf_' is always prefixed to the custom field name you choose.
-                                                                    // e.g., "wikiusername" becomes "pf_wikiusername"
-        
-// Local
-$wgAuth_Config['LoginMessage']   = '<b>Please register on the forums to login.</b><br /><a href="' . $wgAuth_Config['URLToPHPBB'] .
-                                   'ucp.php?mode=register">Click here to create an account.</a>'; // Localize this message.
-$wgAuth_Config['NoWikiError']    = 'You must be a member of the required forum group.'; // Localize this message.
-        
-$wgAuth = new Auth_phpBB($wgAuth_Config);     // Auth_phpBB Plugin.
+    $wgAuth_Config['ProfileDataTB']    = 'phpbb3_profile_fields_data';  // Name of your phpBB profile data table. (e.g. phpbb_profile_fields_data)
+    
+    $wgAuth_Config['ProfileFieldName'] = 'pf_wikiusername';             // Name of your phpBB custom profile field
+                                                                        // The 'pf_' is always prefixed to the custom field name you choose.
+                                                                        // e.g., "wikiusername" becomes "pf_wikiusername"
+    
+    // Local
+    $wgAuth_Config['LoginMessage']   = '<b>Please register on the forums to login.</b><br /><a href="' . $wgAuth_Config['URLToPHPBB'] .
+                                       'ucp.php?mode=register">Click here to create an account.</a>'; // Localize this message.
+    $wgAuth_Config['NoWikiError']    = 'You must be a member of the required forum group.'; // Localize this message.
+    
+    $wgAuth = new Auth_phpBB($wgAuth_Config);     // Auth_phpBB Plugin.

--- a/README.md
+++ b/README.md
@@ -10,79 +10,117 @@ REQUIREMENTS
 
 * PHP5
 * MySQL 5
-* MediaWiki 1.11+ 
+* MediaWiki 1.11+
 * phpBB 3.2
 
 INSTALL:
 =================
 
-Create a group in PHPBB for your wiki users. I named mine "Wiki". 
+Create a group in phpBB for your wiki users. I named mine "Wiki". 
 You will need to put the name you choose in the code below. 
 
-NOTE: In order for a user to be able to use the wiki they will need to 
+PHPBB GROUP NOTE: In order for a user to be able to use the wiki they will need to 
 be a member of the group you made in the step above.
 
-Put Auth_phpbb.php in /extensions/  
-Put iAuthPlugin.php in /extensions/  
-Put PasswordHash.php in /extensions/
+Put Auth_phpbb.php in /extensions/Auth_phpBB
+Put iAuthPlugin.php in /extensions/Auth_phpBB
+Put PasswordHash.php in /extensions/Auth_phpBB
 
+OPTIONAL PHPBB-TO-MEDIAWIKI USERNAME TRANSLATION FEATURE:
+phpBB usernames can be translated to more restrictive wiki usernames.
+Use phpBB ACP, Users and Groups, Custom profile fields.
+Create a "Single text field" custom profile field.
+Suggested settings:
+  Name it "wikiusername"
+  Set "Publicly display profile field" = no
+  Uncheck all visibility options, except check "Hide profile field" 
+  Set "Field name/title presented to the user" = "Wiki Username"
+  Set "Field description" = "Forum username translated for wiki username restrictions"
+  Set "Length of input box" = 20
+  Set "Maximum number of characters" = 255
+  Set "Field validation" to "Any character"
+  Set Language definitions fields to same as field name/title/description above.
+
+PROFILE NOTE:
+The custom profile field must be hidden to all but the admins
+because users could otherwise hijack wiki accounts by entering any
+username they wish.
+
+PROFILE NOTE:
+Enter a valid MediaWiki username into this field in the user's
+profile only when the phpBB username conflicts with MediaWiki username restrictions.
+For example, enter "Under Score" for a user with the name "Under_Score" because
+underscores are not allowed in MediaWiki usernames.  All users with phpBB usernames
+which are also valid MediaWiki usernames do not need this field set.
 
 Open LocalSettings.php. Put this at the bottom of the file. Edit as needed.
 
-        /*-----------------[ Everything below this line. ]-----------------*/
+/*-----------------[ Everything below this line. ]-----------------*/
         
-        // PHPBB User Database Plugin. (Requires MySQL Database)
-        require_once './extensions/Auth_phpbb.php';
+// phpBB User Database Plugin. (Requires MySQL Database)
+require_once '$IP/extensions/Auth_phpBB/Auth_phpbb.php';
         
-        $wgAuth_Config = array(); // Clean.
+$wgAuth_Config = array(); // Clean.
 
-        $wgAuth_Config['UseCanonicalCase'] = true;      // Setting this to true causes the mediawiki usernames
-                                                        // to match the casing of the phpbb ones (except with
-                                                        // the first letter set uppercase.)
-                                                        // Setting this to false causes usernames to be all
-                                                        // lowercase except for the first character.
-                                                        // Before June 2016 this setting was always false,
-                                                        // changing it to true on an install where it previously
-                                                        // was false will cause users with uppercase characters
-                                                        // to appear as separate users from their previous
-                                                        // all-lowercase account.
+$wgAuth_Config['UseCanonicalCase'] = true;      // Setting this to true causes the MediaWiki usernames
+                                                // to match the casing of the phpBB ones (except with
+                                                // the first letter set uppercase.)
+                                                // Setting this to false causes usernames to be all
+                                                // lowercase except for the first character.
+                                                // Before June 2016 this setting was always false,
+                                                // changing it to true on an install where it previously
+                                                // was false will cause users with uppercase characters
+                                                // to appear as separate users from their previous
+                                                // all-lowercase account.
         
-        $wgAuth_Config['WikiGroupName'] = 'Wiki';       // Name of your PHPBB group
-                                                        // users need to be a member
-                                                        // of to use the wiki. (i.e. wiki)
-                                                        // This can also be set to an array 
-                                                        // of group names to use more then 
-                                                        // one. (ie. 
-                                                        // $wgAuth_Config['WikiGroupName'][] = 'Wiki';
-                                                        // $wgAuth_Config['WikiGroupName'][] = 'Wiki2';
-                                                        // or
-                                                        // $wgAuth_Config['WikiGroupName'] = array('Wiki', 'Wiki2');
-                                                        // )
+$wgAuth_Config['WikiGroupName'] = 'Wiki';       // Name of your phpBB group
+                                                // users need to be a member
+                                                // of to use the wiki. (i.e. wiki)
+                                                // This can also be set to an array 
+                                                // of group names to use more then 
+                                                // one. (ie. 
+                                                // $wgAuth_Config['WikiGroupName'][] = 'Wiki';
+                                                // $wgAuth_Config['WikiGroupName'][] = 'Wiki2';
+                                                // or
+                                                // $wgAuth_Config['WikiGroupName'] = array('Wiki', 'Wiki2');
+                                                // )
         
         
-        $wgAuth_Config['UseWikiGroup'] = true;          // This tells the Plugin to require
-                                                        // a user to be a member of the above
-                                                        // phpBB group. (ie. wiki) Setting
-                                                        // this to false will let any phpBB
-                                                        // user edit the wiki.
+$wgAuth_Config['UseWikiGroup'] = true;          // This tells the Plugin to require
+                                                // a user to be a member of the above
+                                                // phpBB group. (ie. wiki) Setting
+                                                // this to false will let any phpBB
+                                                // user edit the wiki.
         
-        $wgAuth_Config['UseExtDatabase'] = false;       // This tells the plugin that the phpBB tables
-                                                        // are in a different database then the wiki.
-                                                        // The default settings is false.
+$wgAuth_Config['UseExtDatabase'] = false;       // This tells the plugin that the phpBB tables
+                                                // are in a different database then the wiki.
+                                                // The default settings is false.
         
-        //$wgAuth_Config['MySQL_Host']        = 'localhost';      // phpBB MySQL Host Name.
-        //$wgAuth_Config['MySQL_Username']    = 'username';       // phpBB MySQL Username.
-        //$wgAuth_Config['MySQL_Password']    = 'password';       // phpBB MySQL Password.
-        //$wgAuth_Config['MySQL_Database']    = 'database';       // phpBB MySQL Database Name.
+//$wgAuth_Config['MySQL_Host']        = 'localhost';      // phpBB MySQL Host Name.
+//$wgAuth_Config['MySQL_Port']        = '';               // phpBB MySQL Port number.
+//$wgAuth_Config['MySQL_Username']    = 'username';       // phpBB MySQL Username.
+//$wgAuth_Config['MySQL_Password']    = 'password';       // phpBB MySQL Password.
+//$wgAuth_Config['MySQL_Database']    = 'database';       // phpBB MySQL Database Name.
         
-        $wgAuth_Config['UserTB']         = 'phpbb3_users';       // Name of your PHPBB user table. (i.e. phpbb_users)
-        $wgAuth_Config['GroupsTB']       = 'phpbb3_groups';      // Name of your PHPBB groups table. (i.e. phpbb_groups)
-        $wgAuth_Config['User_GroupTB']   = 'phpbb3_user_group';  // Name of your PHPBB user_group table. (i.e. phpbb_user_group)
-        $wgAuth_Config['PathToPHPBB']    = '../phpbb3/';         // Path from this file to your phpBB install.
+$wgAuth_Config['UserTB']         = 'phpbb3_users';       // Name of your phpBB user table. (i.e. phpbb_users)
+$wgAuth_Config['GroupsTB']       = 'phpbb3_groups';      // Name of your phpBB groups table. (i.e. phpbb_groups)
+$wgAuth_Config['User_GroupTB']   = 'phpbb3_user_group';  // Name of your phpBB user_group table. (i.e. phpbb_user_group)
+$wgAuth_Config['PathToPHPBB']    = '../phpbb3/';         // Path from this file to your phpBB install.
+$wgAuth_Config['URLToPHPBB']     = 'http://www.domain.com/phpbb3/'; // URL of your phpBB install.
+
+$wgAuth_Config['UseWikiProfile']   = false;   // Whether the extension checks for a custom username profile
+                                              // field in phpBB when the phpBB username is incompatible with
+                                              // MediaWiki username restrictions.
+
+$wgAuth_Config['ProfileDataTB']    = 'phpbb3_profile_fields_data';  // Name of your phpBB profile data table. (e.g. phpbb_profile_fields_data)
+
+$wgAuth_Config['ProfileFieldName'] = 'pf_wikiusername';             // Name of your phpBB custom profile field
+                                                                    // The 'pf_' is always prefixed to the custom field name you choose.
+                                                                    // e.g., "wikiusername" becomes "pf_wikiusername"
         
-        // Local
-        $wgAuth_Config['LoginMessage']   = '<b>You need a phpBB account to login.</b><br /><a href="' . $wgAuth_Config['PathToPHPBB'] .
-                                           'ucp.php?mode=register">Click here to create an account.</a>'; // Localize this message.
-        $wgAuth_Config['NoWikiError']    = 'You are not a member of the required phpBB group.'; // Localize this message.
+// Local
+$wgAuth_Config['LoginMessage']   = '<b>Please register on the forums to login.</b><br /><a href="' . $wgAuth_Config['URLToPHPBB'] .
+                                   'ucp.php?mode=register">Click here to create an account.</a>'; // Localize this message.
+$wgAuth_Config['NoWikiError']    = 'You must be a member of the required forum group.'; // Localize this message.
         
-        $wgAuth = new Auth_phpBB($wgAuth_Config);     // Auth_phpBB Plugin.
+$wgAuth = new Auth_phpBB($wgAuth_Config);     // Auth_phpBB Plugin.


### PR DESCRIPTION
Implement username translation from phpBB to MediaWiki using phpBB Custom Profiles to accommodate Mediawiki character restrictions, plus a few other improvements.

Install folder moved from root extensions folder to extensions/Auth_phpBB.
Database port may be overtly specified.
phpBB installation may be on different subdomain than MediaWiki.
Used the Installation Path variable $IP instead of relative reference in path to the extensions folder.
Updated README.md for changes.