### PR TITLE
Fix PathToPHPBB to work with absolute paths

### DIFF
--- a/Auth_phpbb.php
+++ b/Auth_phpbb.php
@@ -664,11 +664,8 @@ class Auth_phpBB extends AuthPlugin implements iAuthPlugin
      */
     private function loadPHPFiles($FileSet)
     {
-        $GLOBALS['phpbb_root_path'] = $this->_PathToPHPBB; // Path to phpBB
+        $GLOBALS['phpbb_root_path'] = rtrim($this->_PathToPHPBB, '/') . '/'; // Path to phpBB
         $GLOBALS['phpEx']           = substr(strrchr(__FILE__, '.'), 1); // File Ext.
-
-        //$phpbb_root_path = $this->_PathToPHPBB; // Path to phpBB
-        //$phpEx = substr(strrchr(__FILE__, '.'), 1); // File Ext.
 
         // Check that path is valid.
         if (!is_dir($this->_PathToPHPBB))
@@ -680,8 +677,8 @@ class Auth_phpBB extends AuthPlugin implements iAuthPlugin
         {
             case 'UTF8':
                 // Check for UTF file.
-                $utfToolsPath = implode('/',array_filter(explode('/', $this->_PathToPHPBB . '/includes/utf/utf_tools.php')));
-                $autoloadPath = implode('/',array_filter(explode('/', $this->_PathToPHPBB . '/vendor/autoload.php')));
+                $utfToolsPath = rtrim($this->_PathToPHPBB, '/') . '/includes/utf/utf_tools.php';
+                $autoloadPath = rtrim($this->_PathToPHPBB, '/') . '/vendor/autoload.php';
 
                 if (!is_file($utfToolsPath))
                 {


### PR DESCRIPTION
My previous fix to trailing slashes accidentally broke absolute paths, as seen in #29. This fix *should* work in all cases, specifically I tested it with

* Relative path without trailing slash
* Relative path with trailing slash
* Absolute path without trailing slash
* Absolute path with trailing slash

But in case it breaks more, could somebody else test it? Can anybody think of other cases it might fail? Should we use realpath() instead?