### PR TITLE
Update to use PluggableAuth 6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ REQUIREMENTS
 
 * PHP 7.3 or later
 * MySQL 5 or later
-* MediaWiki 1.31 LTS or later up to 1.37 (tested on 1.31, 1.35 and 1.37) not compatible with 1.38
+* MediaWiki 1.35 LTS or later (tested on 1.35)
 * phpBB 3.3 (tested on 3.3.3 and 3.3.7)
-* [PluggableAuth](https://www.mediawiki.org/wiki/Extension:PluggableAuth) 5.7 MediaWiki extension
+* [PluggableAuth extension](https://www.mediawiki.org/wiki/Extension:PluggableAuth) 6.1 or later
 
 INSTALL
 =================

--- a/extension.json
+++ b/extension.json
@@ -1,26 +1,34 @@
 {
-	"name": "Auth_phpBB",
-	"author": [
-            "Nicholas Dunnaway",
-            "Steve Gilvarry",
-            "Jonathan W. Platt",
-            "C4K3",
-            "Joel Haasnoot",
-            "[https://kence.org Casey Peel]"
-        ],
-	"url": "https://github.com/Digitalroot/MediaWiki_PHPBB_Auth",
-	"description": "Authenticate against a phpBB user database.",
-	"version": "4.0.0",
-	"license-name": "GPL-2.0-or-later",
-	"type": "validextensionclass",
-	"manifest_version": 1,
-	"callback": "Auth_phpBBHooks::onRegistration",
-	"config": {
-		"PluggableAuth_Class": "Auth_phpBB"
-	},
-	"AutoloadClasses": {
-		"Auth_phpBB": "includes/Auth_phpBB.php",
-		"Auth_phpBBHooks": "includes/Auth_phpBBHooks.php",
-		"ExtraLoginFields": "includes/ExtraLoginFields.php"
-	}
+    "name": "Auth_phpBB",
+    "version": "4.1.0",
+    "author": [
+        "Nicholas Dunnaway",
+        "Steve Gilvarry",
+        "Jonathan W. Platt",
+        "C4K3",
+        "Joel Haasnoot",
+        "[https://kence.org Casey Peel]"
+    ],
+    "url": "https://github.com/Digitalroot/MediaWiki_PHPBB_Auth",
+    "description": "Authenticate against a phpBB user database.",
+    "type": "validextensionclass",
+    "license-name": "GPL-2.0-or-later",
+    "requires": {
+        "MediaWiki": ">= 1.35.0",
+        "extensions": {
+            "PluggableAuth": ">= 6.1"
+        }
+    },
+    "AutoloadNamespaces": {
+        "MediaWiki\\Extension\\Auth_phpBB\\": "includes/"
+    },
+    "callback": "MediaWiki\\Extension\\Auth_phpBB\\Auth_phpBBHooks::onRegistration",
+    "attributes": {
+        "PluggableAuth": {
+            "Auth_phpBB": {
+                "class": "MediaWiki\\Extension\\Auth_phpBB\\Auth_phpBB"
+            }
+        }
+    },
+    "manifest_version": 2
 }

--- a/includes/Auth_phpBB.php
+++ b/includes/Auth_phpBB.php
@@ -6,9 +6,6 @@
  * in order to log into the wiki. This can also force the user to
  * be in a group called Wiki.
  *
- * With 4.0.x release this code was rewritten to make better use of
- * objects and php7. Works with MediaWiki 1.31.x (LTS), PHPBB3.3.x and PHP7.4.
- *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -39,8 +36,13 @@
  *
  */
 
+namespace MediaWiki\Extension\Auth_phpBB;
+
 use MediaWiki\Auth\AuthManager;
+use MediaWiki\User\UserIdentity;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Extension\PluggableAuth\PluggableAuth;
+use MediaWiki\Extension\PluggableAuth\PluggableAuthLogin;
 use User;
 
 /**
@@ -284,7 +286,7 @@ class Auth_phpBB extends PluggableAuth {
      * @param string &$errorMessage
      * @return bool true if user is authenticated, false otherwise
      */
-    public function authenticate( &$id, &$username, &$realname, &$email, &$errorMessage )
+    public function authenticate( &$id, &$username, &$realname, &$email, &$errorMessage ): bool
     {
         $this->initialize_config();
 
@@ -391,7 +393,7 @@ class Auth_phpBB extends PluggableAuth {
      *
      * @param int $id user id
      */
-    public function saveExtraAttributes( $id )
+    public function saveExtraAttributes( $id ): void
     {
         // nothing to do
     }
@@ -403,11 +405,19 @@ class Auth_phpBB extends PluggableAuth {
      *
      * @param User &$user
      */
-    public function deauthenticate( User &$user )
+    public function deauthenticate( UserIdentity &$user ): void
     {
         // nothing to do
     }
 
+    /**
+     * Populates the login page for this plugin.
+     * [used by PluggableAuth]
+     */
+    public static function getExtraLoginFields(): array
+    {
+        return (array)( new ExtraLoginFields() );
+    }
 
     /**
      * Connect to the database. All of these settings are from the
@@ -425,12 +435,12 @@ class Auth_phpBB extends PluggableAuth {
             $dbHostAddr = ($this->_MySQL_Port == '' ? $this->_MySQL_Host : $this->_MySQL_Host . ':' . $this->_MySQL_Port);
 
             // Connect to database. I supress the error here.
-            $fresMySQLConnection = new mysqli($dbHostAddr, $this->_MySQL_Username,
+            $fresMySQLConnection = new \mysqli($dbHostAddr, $this->_MySQL_Username,
                 $this->_MySQL_Password, $this->_MySQL_Database);
 
         } else {
             // Connect to database.
-            $fresMySQLConnection = new mysqli($GLOBALS['wgDBserver'], $GLOBALS['wgDBuser'],
+            $fresMySQLConnection = new \mysqli($GLOBALS['wgDBserver'], $GLOBALS['wgDBuser'],
                 $GLOBALS['wgDBpassword'], $GLOBALS['wgDBname']);
         }
 

--- a/includes/Auth_phpBBHooks.php
+++ b/includes/Auth_phpBBHooks.php
@@ -30,6 +30,8 @@
      * @link http://digitalroot.net/
      */
 
+namespace MediaWiki\Extension\Auth_phpBB;
+
 /**
  * Class Auth_phpBBHooks
  * @author  Casey Peel
@@ -43,7 +45,12 @@ class Auth_phpBBHooks {
      */
     public static function onRegistration()
     {
-        $GLOBALS['wgPluggableAuth_ExtraLoginFields'] = (array)( new ExtraLoginFields() );
+        $GLOBALS['wgPluggableAuth_Config'] = [
+            "login" => [
+                'plugin' => 'Auth_phpBB',
+                'buttonLabelMessage' => 'Log in',
+            ]
+        ];
 
         // This requires a user be logged into the wiki to make changes.
         $GLOBALS['wgGroupPermissions']['*']['edit'] = false;

--- a/includes/ExtraLoginFields.php
+++ b/includes/ExtraLoginFields.php
@@ -30,6 +30,8 @@
  * @link http://digitalroot.net/
  */
 
+namespace MediaWiki\Extension\Auth_phpBB;
+
 /**
  * Class ExtraLoginFields
  * Inspired by LDAPAuthentication2 extension


### PR DESCRIPTION
Update this plugin to support PluggableAuth 6.1 and later which works with MediaWiki 1.35 LTS and later. PluggableAuth 6.x breaks compatibility with 5.x due to the introduction of namespaces, so it is not possible to have an Auth_phpBB release that supports both.

I've rev'd the version to 4.1.0 to indicate that this is an important change due to the middleware version update, but since there was no functional change to the plugin itself it doesn't feel like a 5.x version is appropriate. I welcome feedback on that.

There's a lot of noise in the update to `extension.json`. I took this opportunity to reorder the fields to be in a more logical order and standardize on tabs rather than a mix of tabs and spaces (although at this point there's enough change that perhaps I should have just taken the plunge and moved to spaces).

Fixes https://github.com/Digitalroot-Technologies/MediaWiki_PHPBB_Auth/issues/59