### PR TITLE
Update README with clear version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,18 @@ REQUIREMENTS
 
 * PHP 7.3 or later
 * MySQL 5 or later
-* MediaWiki 1.35 LTS or later (tested on 1.35)
+* MediaWiki 1.35 LTS or later (tested on 1.35 and 1.39)
 * phpBB 3.3 (tested on 3.3.3 and 3.3.7)
-* [PluggableAuth extension](https://www.mediawiki.org/wiki/Extension:PluggableAuth) 6.1 or later
+* [PluggableAuth extension](https://www.mediawiki.org/wiki/Extension:PluggableAuth)
+
+Version Compatibility Matrix
+----------------------------
+
+| MediaWiki | PluggableAuth | MediaWiki_PHPBB_Auth |
+| --------- | ------------- | -------------------- |
+| > 1.35    | 6.x or 7.x    | 4.1.0                |
+| 1.35      | 5.7           | 4.0.0                |
+| < 1.35    | n/a           | 3.x                  |
 
 INSTALL
 =================


### PR DESCRIPTION
PluggableAuth 6.x works with MediaWiki 1.35 and Auth_phpBB 4.1.0, but the [ExtensionDistributor for PluggableAuth](https://www.mediawiki.org/wiki/Special:ExtensionDistributor/PluggableAuth) downloads PluggableAuth 5.7 for MW 1.35 which _doesn't_ work with Auth_phpBB 4.1.0 -- however, 4.0.0 _does_. And indeed you can't actually download PluggableAuth 6.x without doing so directly from git.

Update the README with clear version requirements for what versions of this extension work with what parts of MW and PluggableAuth.

This should "fix" https://github.com/Digitalroot-Technologies/MediaWiki_PHPBB_Auth/issues/65 by making it clear the right versions needed.