### PR TITLE
Fix buttonLabelMessage label

### DIFF
--- a/includes/Auth_phpBBHooks.php
+++ b/includes/Auth_phpBBHooks.php
@@ -48,7 +48,7 @@ class Auth_phpBBHooks {
         $GLOBALS['wgPluggableAuth_Config'] = [
             "login" => [
                 'plugin' => 'Auth_phpBB',
-                'buttonLabelMessage' => 'Log in',
+                'buttonLabelMessage' => 'login',
             ]
         ];
 


### PR DESCRIPTION
Per https://www.mediawiki.org/wiki/Extension:PluggableAuth the buttonLabelMessage is supposed to be a system message key. With a value of "Log in" you end up with "{Log in}" (with curly braces) on the button since the system can't find that message key. On mediawiki 1.39 the /Special:AllMessages page shows that "login" in the label for the English phrase "Log in".